### PR TITLE
Jhipster angularx changes

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -51,6 +51,12 @@ module.exports = yeoman.Base.extend({
       this.searchEngine = config.searchEngine;
       this.enableTranslation = config.enableTranslation;
       this.clientFramework = config.clientFramework;
+
+      // for backwards compatability
+      if (this.clientFramework === 'angular2') {
+        this.clientFramework = 'angularX'
+      }
+
       // set the major version to 2 if it isn't specifified
       this.jhipsterVersion = config.jhipsterVersion;
       if (!this.jhipsterVersion) {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -4,6 +4,7 @@ var chalk = require('chalk');
 var packagejs = require(__dirname + '/../../package.json');
 var shelljs = require('shelljs');
 var fs = require('fs');
+var semver = require('semver');
 
 // Stores JHipster variables
 var jhipsterVar = {moduleName: 'elasticsearch-reindexer'};
@@ -57,12 +58,13 @@ module.exports = yeoman.Base.extend({
       } else {
         this.jhipsterMajorVersion = config.jhipsterVersion[0];
       }
+      this.requiresSetLocation = semver.lt(this.jhipsterVersion, '4.4.4');
       this.entityFiles = shelljs.ls(jhipsterVar.jhipsterConfigDirectory).filter(function (file) {
         return file.match(/\.json$/);
       });
       this.packageName = jhipsterVar.packageName;
       this.angularAppName = jhipsterVar.angularAppName;
-      this.angularXAppName = jhipsterVar.angularXAppName;
+      this.angularXAppName = jhipsterVar.angularXAppName || jhipsterVar.angular2AppName;
       if (this.angularXAppName === undefined) {
           this.angularXAppName = jhipsterVar.baseName;
       }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -62,9 +62,9 @@ module.exports = yeoman.Base.extend({
       });
       this.packageName = jhipsterVar.packageName;
       this.angularAppName = jhipsterVar.angularAppName;
-      this.angular2AppName = jhipsterVar.angular2AppName;
-      if (this.angular2AppName === undefined) {
-          this.angular2AppName = jhipsterVar.baseName;
+      this.angularXAppName = jhipsterVar.angularXAppName;
+      if (this.angularXAppName === undefined) {
+          this.angularXAppName = jhipsterVar.baseName;
       }
 
       if (this.jhipsterMajorVersion > 2) {
@@ -134,7 +134,7 @@ module.exports = yeoman.Base.extend({
             jhipsterFunc.addAdminElementTranslationKey('elasticsearch-reindex', 'Reindex Elasticsearch', this.nativeLanguage);
           }
         }
-      } else if (this.clientFramework === 'angular2') {
+      } else if (this.clientFramework === 'angularX') {
         this.template('src/main/webapp/ts/_elasticsearch-reindex-modal.component.html', jhipsterVar.webappDir + this.appFolder + '/elasticsearch-reindex-modal.component.html', this, {});
         this.template('src/main/webapp/ts/_elasticsearch-reindex-modal.component.ts', jhipsterVar.webappDir + this.appFolder + '/elasticsearch-reindex-modal.component.ts', this, {});
         this.template('src/main/webapp/ts/_elasticsearch-reindex.component.html', jhipsterVar.webappDir + this.appFolder + '/elasticsearch-reindex.component.html', this, {});
@@ -144,11 +144,11 @@ module.exports = yeoman.Base.extend({
         this.template('src/main/webapp/ts/_elasticsearch-reindex.service.ts', jhipsterVar.webappDir + this.appFolder + '/elasticsearch-reindex.service.ts', this, {});
         this.template('src/main/webapp/ts/_index.ts', jhipsterVar.webappDir + this.appFolder + '/index.ts', this, {});
         if (jhipsterFunc.addAdminToModule) {
-          jhipsterFunc.addAdminToModule(jhipsterVar.angular2AppName, 'ElasticsearchReindex', 'elasticsearch-reindex', 'elasticsearch-reindex', this.enableTranslation, this.clientFramework);
+          jhipsterFunc.addAdminToModule(this.angularXAppName, 'ElasticsearchReindex', 'elasticsearch-reindex', 'elasticsearch-reindex', this.enableTranslation, this.clientFramework);
         } else {
           this.log(chalk.yellow('WARNING the function addAdminToModule is missing, you need to add the missing import in src/main/webapp/app/admin/admin.module.ts:'));
-          this.log(chalk.yellow('  - at the beginning of the file: ') + 'import { ' + this.angular2AppName + 'ElasticsearchReindexModule } from \'./elasticsearch-reindex/elasticsearch-reindex.module\';');
-          this.log(chalk.yellow('  - inside @NgModule, imports: ') + this.angular2AppName + 'ElasticsearchReindexModule\n');
+          this.log(chalk.yellow('  - at the beginning of the file: ') + 'import { ' + this.angularXAppName + 'ElasticsearchReindexModule } from \'./elasticsearch-reindex/elasticsearch-reindex.module\';');
+          this.log(chalk.yellow('  - inside @NgModule, imports: ') + this.angularXAppName + 'ElasticsearchReindexModule\n');
         }
         if (jhipsterFunc.addElementToAdminMenu) {
           jhipsterFunc.addElementToAdminMenu('elasticsearch-reindex', 'fw fa-search', this.enableTranslation, this.clientFramework);

--- a/generators/app/templates/src/main/webapp/ts/_elasticsearch-reindex.component.ts
+++ b/generators/app/templates/src/main/webapp/ts/_elasticsearch-reindex.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-<%_ if (enableTranslation) { _%>
+<%_ if (enableTranslation && requiresSetLocation) { _%>
 import { JhiLanguageService } from 'ng-jhipster';
 <%_ } _%>
 
@@ -13,11 +13,11 @@ import { ElasticsearchReindexModalComponent } from './elasticsearch-reindex-moda
 export class ElasticsearchReindexComponent {
 
     constructor(
-        <%_ if (enableTranslation) { _%>
+        <%_ if (enableTranslation && requiresSetLocation) { _%>
         private jhiLanguageService: JhiLanguageService,
         <%_ } _%>
         private modalService: NgbModal
-    )<%_ if (enableTranslation) { %> {
+    )<%_ if (enableTranslation && requiresSetLocation) { %> {
         this.jhiLanguageService.setLocations(['elasticsearch-reindex']);
     }<%_ } else { %> { }<%_ } %>
 

--- a/generators/app/templates/src/main/webapp/ts/_elasticsearch-reindex.module.ts
+++ b/generators/app/templates/src/main/webapp/ts/_elasticsearch-reindex.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { <%=angular2AppName%>SharedModule } from '../../shared';
+import { <%=angularXAppName%>SharedModule } from '../../shared';
 
 import {
     ElasticsearchReindexComponent,
@@ -16,7 +16,7 @@ const ADMIN_ROUTES = [
 
 @NgModule({
     imports: [
-        <%=angular2AppName%>SharedModule,
+        <%=angularXAppName%>SharedModule,
         RouterModule.forRoot(ADMIN_ROUTES, { useHash: true })
     ],
     declarations: [
@@ -32,4 +32,4 @@ const ADMIN_ROUTES = [
     schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
 
-export class <%=angular2AppName%>ElasticsearchReindexModule {}
+export class <%=angularXAppName%>ElasticsearchReindexModule {}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chalk": "1.1.1",
     "mkdirp": "0.5.1",
     "generator-jhipster": ">2.26.0",
+    "semver": "5.4.1",
     "shelljs": "0.5.3",
     "fs-extra": "0.30.0"
   },


### PR DESCRIPTION
JHipster changed the value of clientFramework from `angular2` to `angularX` recently.  Another change is that languages are now bundled for Angular, which removes the following method: `this.jhiLanguageService.setLocations(['elasticsearch-reindex']);`

On a related note, JHipster had a big update for modules which changes how you compose the main generator.  I have another PR ready but I decided to split it up to keep the changes simple.

By the way, the last release was v0.3.0 which means Angular 2 frontend support was never actually released on NPM.