### PR TITLE
use pagination and load relationships during reindex process

### DIFF
--- a/generators/app/templates/src/main/java/package/service/_ElasticsearchIndexService.java
+++ b/generators/app/templates/src/main/java/package/service/_ElasticsearchIndexService.java
@@ -152,25 +152,25 @@ public class ElasticsearchIndexService {
         }
         elasticsearchTemplate.putMapping(entityClass);
         if (jpaRepository.count() > 0) {
-          // if a JHipster entity field is the owner side of a many-to-many relationship, it should be loaded manually
-          List<Method> relationshipGetters = Arrays.stream(entityClass.getDeclaredFields())
-            .filter(field -> field.getType().equals(Set.class))
-            .filter(field -> field.getAnnotation(ManyToMany.class) != null)
-            .filter(field -> field.getAnnotation(ManyToMany.class).mappedBy().isEmpty())
-            .filter(field -> field.getAnnotation(JsonIgnore.class) == null)
-            .map(field -> {
-              try {
-                return new PropertyDescriptor(field.getName(), entityClass).getReadMethod();
-              } catch (IntrospectionException e) {
-                log.error("Error retrieving getter for class {}, field {}. Field will NOT be indexed",
-                  entityClass.getSimpleName(), field.getName(), e);
-                return null;
-              }
-            })
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+            // if a JHipster entity field is the owner side of a many-to-many relationship, it should be loaded manually
+            List<Method> relationshipGetters = Arrays.stream(entityClass.getDeclaredFields())
+                .filter(field -> field.getType().equals(Set.class))
+                .filter(field -> field.getAnnotation(ManyToMany.class) != null)
+                .filter(field -> field.getAnnotation(ManyToMany.class).mappedBy().isEmpty())
+                .filter(field -> field.getAnnotation(JsonIgnore.class) == null)
+                .map(field -> {
+                    try {
+                        return new PropertyDescriptor(field.getName(), entityClass).getReadMethod();
+                    } catch (IntrospectionException e) {
+                        log.error("Error retrieving getter for class {}, field {}. Field will NOT be indexed",
+                            entityClass.getSimpleName(), field.getName(), e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
 
-          int size = 100;
+            int size = 100;
             for (int i = 0; i <= jpaRepository.count() / size; i++) {
                 Pageable page = new PageRequest(i, size);
                 log.info("Indexing page {} of {}, size {}", i, jpaRepository.count() / size, size);


### PR DESCRIPTION
Should hopefully fix #37 and #17.  It uses `findAll(pageable)` for all entities, then loads any relationships eagerly.  If it's not what you are looking for, feel free to close.

I couldn't get any OutOfMemoryErrors, any special instructions to reproduce would help.  I tested with a dockerized app, limiting memory via JAVA_OPTS.  I had a couple hundred entities of each type using the following JDL:
```
// JDL definition for application 'elastic' generated with command 'jhipster export-jdl'

entity Foo (foo) {
  name String
}
entity Bar (bar) {
  name String
}
entity Baz (baz) {
  name String
}
entity DoubleRelationship (tree_top) {
  name String
}

relationship ManyToMany {
  Bar{foo(name)} to Foo{bar},
  Baz{bar(name)} to Bar{baz},
  DoubleRelationship{baz(name)} to Baz{DoubleRelationship},
  DoubleRelationship{bar(name)} to Bar{DoubleRelationship}
}

dto Foo, Bar, Baz, DoubleRelationship with mapstruct
paginate Foo, Bar, Baz, DoubleRelationship with pagination
service Foo, Bar, Baz, DoubleRelationship with serviceClass
```