### PR TITLE
fixed some import issue in the ts file and the ElasticSearchTemplate issue.

### DIFF
--- a/.angulardoc.json
+++ b/.angulardoc.json
@@ -1,0 +1,4 @@
+{
+  "repoId": "f037271e-90c0-4c44-abe2-bafc10aab229",
+  "lastSync": 0
+}

--- a/generators/app/templates/src/main/java/package/service/_ElasticsearchIndexService.java
+++ b/generators/app/templates/src/main/java/package/service/_ElasticsearchIndexService.java
@@ -6,6 +6,7 @@ import <%=packageName%>.domain.*;
 import <%=packageName%>.repository.*;
 import <%=packageName%>.repository.search.*;
 import org.elasticsearch.indices.IndexAlreadyExistsException;
+import com.github.vanroy.springdata.jest.JestElasticsearchTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -59,7 +60,7 @@ public class ElasticsearchIndexService {
     private final UserSearchRepository userSearchRepository;
 
     <%_ } _%>
-    private final ElasticsearchTemplate elasticsearchTemplate;
+    private final JestElasticsearchTemplate elasticsearchTemplate;
 
     public ElasticsearchIndexService(
         <%_ if (!skipUserManagement && (applicationType === 'monolith' || applicationType === 'gateway')) { _%>
@@ -75,7 +76,7 @@ public class ElasticsearchIndexService {
         <%_
             });
         } _%>
-        ElasticsearchTemplate elasticsearchTemplate) {
+        JestElasticsearchTemplate elasticsearchTemplate) {
         <%_ if (!skipUserManagement && (applicationType === 'monolith' || applicationType === 'gateway')) { _%>
         this.userRepository = userRepository;
         this.userSearchRepository = userSearchRepository;
@@ -113,7 +114,7 @@ public class ElasticsearchIndexService {
 
     <%_ } _%>
     @Inject
-    private ElasticsearchTemplate elasticsearchTemplate;
+    private JestElasticsearchTemplate elasticsearchTemplate;
 <%_ } _%>
 
     @Async

--- a/generators/app/templates/src/main/webapp/html/elasticsearch-reindex-dialog.html
+++ b/generators/app/templates/src/main/webapp/html/elasticsearch-reindex-dialog.html
@@ -2,7 +2,7 @@
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
                 ng-click="vm.clear()">&times;</button>
-        <h4 class="modal-title"<% if (enableTranslation) { %> data-translate="elasticsearch.reindex.dialog.title"<% } %>>Confirm reindex operation</h4>
+        <h4 class="modal-title" <% if (enableTranslation) { %> data-translate="elasticsearch.reindex.dialog.title"<% } %>>Confirm reindex operation</h4>
     </div>
     <div class="modal-body">
         <jh<% if (jhipsterMajorVersion > 2) { %>i<% } %>-alert-error></jh<% if (jhipsterMajorVersion > 2) { %>i<% } %>-alert-error>

--- a/generators/app/templates/src/main/webapp/ts/_elasticsearch-reindex.route.ts
+++ b/generators/app/templates/src/main/webapp/ts/_elasticsearch-reindex.route.ts
@@ -1,5 +1,5 @@
 import { Route } from '@angular/router';
-import { UserRouteAccessService } from '../../shared';
+import { UserRouteAccessService } from '../../core';
 import { ElasticsearchReindexComponent } from './elasticsearch-reindex.component';
 
 export const elasticsearchReindexRoute: Route = {

--- a/generators/app/templates/src/main/webapp/ts/_elasticsearch-reindex.service.ts
+++ b/generators/app/templates/src/main/webapp/ts/_elasticsearch-reindex.service.ts
@@ -4,7 +4,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 <%_ } else {_%>
 import { Http, Response } from '@angular/http';
 <%_ } %>
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs';
 
 @Injectable()
 export class ElasticsearchReindexService {


### PR DESCRIPTION
1. Since Jhipster currently use JestElasticSearchTemplate, using this module may cause some bean initialization issue beause it uses ElasticSearchTemplate instead of JestElasticSearchTemplate. Altough these two implements the same interface - ElasticSearchOperation, but are two different class, basically.  The issue is reproduced easily, when you use this module in your newly-generated jhipster application, once run, you would find there is no qualified bean of ElasticSearchTemplate, since in the elastic configuration file, it configures the JestElasticSearchTemplate, so I changed ElasticSearchTemplate to JestElasticSearchTemplate to remove this confliction.

2. in the ts file, the "UserRouteAccessService" is not in the shared module at this stage, instead, it's in the core module in the current version of jhipster. Another issue is you should import Observable from rxjs, not from the rxjs/Rx, which would cause some import issues.