### PR TITLE
Update _ElasticsearchIndexService.java

### DIFF
--- a/generators/app/templates/src/main/java/package/service/_ElasticsearchIndexService.java
+++ b/generators/app/templates/src/main/java/package/service/_ElasticsearchIndexService.java
@@ -202,7 +202,7 @@ public class ElasticsearchIndexService {
                 .collect(Collectors.toList());
 
             int size = 100;
-            for (int i = 0; i <= jpaRepository.count() / size; i++) {
+            for (int i = 0; i < jpaRepository.count() / size; i++) {
                 <%_ if (usePageRequestOf) { _%>
                 Pageable page = PageRequest.of(i, size);
                 <%_ } else { _%>


### PR DESCRIPTION
Here the loop goes through one page too many and throws an error, because the last page does not exist.